### PR TITLE
Add model Host

### DIFF
--- a/app/models/domain_name_system.rb
+++ b/app/models/domain_name_system.rb
@@ -1,4 +1,6 @@
 class DomainNameSystem < ApplicationRecord
+  has_many :hosts, foreign_key: :dns_id
+
   HOST_FORMAT = "(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)"
 
   validates :address, uniqueness: true, format: {

--- a/app/models/host.rb
+++ b/app/models/host.rb
@@ -1,0 +1,8 @@
+class Host < ApplicationRecord
+  belongs_to :dns, class_name: "DomainNameSystem"
+
+  # Adapted from https://github.com/johno/domain-regex/blob/master/index.js
+  DOMAIN_FORMAT = /((?=[a-z0-9-]{1,63}\.)(xn--)?[a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,63}/
+
+  validates :name, format: { with: DOMAIN_FORMAT }, uniqueness: { scope: :dns_id }
+end

--- a/db/migrate/20181128004010_create_hosts.rb
+++ b/db/migrate/20181128004010_create_hosts.rb
@@ -1,0 +1,17 @@
+class CreateHosts < ActiveRecord::Migration[5.2]
+  def up
+    create_table :hosts do |t|
+      t.references :dns, foreign_key: { to_table: :domain_name_systems }, index: true
+      t.string :name
+
+      t.timestamps
+    end
+
+    add_index :hosts, :id
+    add_index :hosts, [ :dns_id, :name ], unique: true
+  end
+
+  def down
+    drop_table :hosts
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,23 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_27_235516) do
+ActiveRecord::Schema.define(version: 2018_11_28_004010) do
 
   create_table "domain_name_systems", force: :cascade do |t|
     t.string "address", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["address"], name: "index_domain_name_systems_on_address", unique: true
+  end
+
+  create_table "hosts", force: :cascade do |t|
+    t.integer "dns_id"
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["dns_id", "name"], name: "index_hosts_on_dns_id_and_name", unique: true
+    t.index ["dns_id"], name: "index_hosts_on_dns_id"
+    t.index ["id"], name: "index_hosts_on_id"
   end
 
 end

--- a/spec/factories/hosts.rb
+++ b/spec/factories/hosts.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :host do
+    association :dns
+    sequence(:name) { |n| "domain#{n}.com" }
+  end
+end

--- a/spec/models/domain_name_system_spec.rb
+++ b/spec/models/domain_name_system_spec.rb
@@ -1,6 +1,15 @@
 require "rails_helper"
 
 describe DomainNameSystem, type: :model do
+  context "associations" do
+    it "has many hosts" do
+      association_reflection = DomainNameSystem.reflect_on_association(:hosts)
+
+      expect(association_reflection.macro).to eq(:has_many)
+      expect(association_reflection.foreign_key).to eq(:dns_id)
+    end
+  end
+
   context "validations" do
     describe "#address" do
       context "when empty" do

--- a/spec/models/host_spec.rb
+++ b/spec/models/host_spec.rb
@@ -1,0 +1,76 @@
+require "rails_helper"
+
+describe Host, type: :model do
+  context "associations" do
+    it "belongs to dns" do
+      association_reflection = Host.reflect_on_association(:dns)
+
+      expect(association_reflection.macro).to eq(:belongs_to)
+      expect(association_reflection.klass).to eq(DomainNameSystem)
+    end
+  end
+
+  context "when validations" do
+    describe "#dns" do
+      context "when empty" do
+        it "is invalid" do
+          host = build(:host, dns: nil)
+
+          expect(host).not_to be_valid
+          expect(host.errors.messages).to include(dns: [ "must exist" ])
+        end
+      end
+
+      context "when present" do
+        it "is valid" do
+          host = build(:host, dns: build(:dns))
+
+          expect(host).to be_valid
+        end
+      end
+    end
+
+    describe "#name" do
+      context "when empty" do
+        it "is invalid" do
+          host = build(:host, name: nil)
+
+          expect(host).not_to be_valid
+          expect(host.errors.messages).to include(name: [ "is invalid" ])
+        end
+      end
+
+      context "when present" do
+        context "when not a valid domain" do
+          it "is invalid" do
+            host = build(:host, name: "example.")
+
+            expect(host).not_to be_valid
+            expect(host.errors.messages).to include(name: [ "is invalid" ])
+          end
+        end
+
+        context "when a valid domain" do
+          context "when there's another host with same name for given dns" do
+            it "is invalid" do
+              other_host = create(:host)
+              dns        = other_host.dns
+              host       = build(:host, dns: dns, name: other_host.name)
+
+              expect(host).not_to be_valid
+              expect(host.errors.messages).to eq(name: [ "has already been taken" ])
+            end
+          end
+
+          context "when there's not other host with same name for given dns" do
+            it "is valid" do
+              host = build(:host, name: "example.com")
+
+              expect(host).to be_valid
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the model `Host`, which stores the hostnames for a `DNS`.