### PR TITLE
Add dns create endpoint

### DIFF
--- a/app/controllers/api/v1/domain_name_systems_controller.rb
+++ b/app/controllers/api/v1/domain_name_systems_controller.rb
@@ -1,0 +1,24 @@
+class Api::V1::DomainNameSystemsController < ApplicationController
+  def create
+    result = Dns::Create.(create_params)
+
+    render json: {
+      success: result.success?,
+      errors: result.errors,
+      id: result.record.id
+    }
+  end
+
+  private
+
+  def create_params
+    params
+      .require(:domain_name_system)
+      .permit(:address)
+      .merge(hosts: host_params)
+  end
+
+  def host_params
+    params.fetch(:hosts, []).map { |host_params| host_params.permit(:name) }
+  end
+end

--- a/app/services/dns/create.rb
+++ b/app/services/dns/create.rb
@@ -2,6 +2,7 @@ module Dns
   class Create
     class Result
       attr_reader :errors
+      attr_accessor :record
 
       def initialize
         @errors = {}
@@ -43,7 +44,8 @@ module Dns
     attr_reader :params, :dns, :hosts, :result
 
     def create_dns
-      @dns = DomainNameSystem.new(dns_params)
+      @dns          = DomainNameSystem.new(dns_params)
+      result.record = dns
       dns.save!
     end
 
@@ -60,7 +62,7 @@ module Dns
     end
 
     def hosts_params
-      params[:hosts].map { |host_params| host_params.merge(dns: dns) }
+      params.fetch(:hosts, []).map { |host_params| host_params.merge(dns: dns) }
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,8 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  namespace :api, constraints: { format: :json } do
+    namespace :v1 do
+      resources :domain_name_systems, only: :create
+    end
+  end
 end

--- a/spec/controllers/api/v1/domain_name_systems_controller_spec.rb
+++ b/spec/controllers/api/v1/domain_name_systems_controller_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+describe Api::V1::DomainNameSystemsController, type: :controller do
+  describe "#create" do
+    context "when params are valid" do
+      it "creates a dns with hostnames" do
+        mocked_result = double(success?: true, errors: {}, record: double(id: 1))
+        allow(Dns::Create).to receive(:call).and_return(mocked_result)
+        params = {
+          domain_name_system: attributes_for(:dns).merge(hosts: [ attributes_for(:host) ])
+        }
+        post :create, params: params
+
+        expect(Dns::Create).to have_received(:call)
+        expect(
+          JSON(response.body)
+        ).to eq("success" => true, "errors" => {}, "id" => 1)
+      end
+    end
+
+    context "when params are invalid" do
+      it "does not create a dns" do
+        mocked_result = double(success?: false, errors: { foo: [ "bar" ] },
+          record: double(id: nil))
+        allow(Dns::Create).to receive(:call).and_return(mocked_result)
+        params = {
+          domain_name_system: attributes_for(:dns).merge(hosts: [ attributes_for(:host) ])
+        }
+        post :create, params: params
+
+        expect(Dns::Create).to have_received(:call)
+        expect(
+          JSON(response.body)
+        ).to eq("success" => false, "errors" => { "foo" => [ "bar" ] }, "id" => nil)
+      end
+    end
+  end
+end

--- a/spec/services/dns/create_spec.rb
+++ b/spec/services/dns/create_spec.rb
@@ -43,6 +43,7 @@ describe Dns::Create do
           result = service.(params)
 
           expect(result).to be_success
+          expect(result.record).not_to be_nil
         end
 
         it "creates a DNS record" do


### PR DESCRIPTION
This PR adds the endpoint `api/v1/domain_name_systems` which creates DNSs with hostnames.